### PR TITLE
Fix java.lang.NoSuchMethodError on non-Folia platforms

### DIFF
--- a/src/main/java/ru/whitebeef/beeflibrary/BeefLibrary.java
+++ b/src/main/java/ru/whitebeef/beeflibrary/BeefLibrary.java
@@ -34,7 +34,7 @@ public final class BeefLibrary extends JavaPlugin {
 
     private static BeefLibrary instance;
     private boolean placeholderAPIHooked = false;
-    private boolean loadWithFolia = false;
+    private boolean isFolia = false;
     private boolean debug = false;
 
     public static BeefLibrary getInstance() {
@@ -77,14 +77,16 @@ public final class BeefLibrary extends JavaPlugin {
 
     }
 
+    /**
+     * Tries to load class from Folia.
+     * If it succeeds {@link BeefLibrary#isFolia}, field will be set to true.
+     */
     private void tryLoadWithFolia() {
         try {
-            loadWithFolia = getPluginMeta().isFoliaSupported();
-            if (loadWithFolia) {
-                getLogger().info("Loaded with Folia!");
-            }
-        } catch (Exception ignored) {
-        }
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            isFolia = true;
+            getLogger().info("Loaded with Folia!");
+        } catch (Exception ignored) {}
     }
 
 
@@ -154,8 +156,14 @@ public final class BeefLibrary extends JavaPlugin {
         return placeholderAPIHooked;
     }
 
-    public boolean isFoliaSupported() {
-        return loadWithFolia;
+    /**
+     * Returns true if plugin is running on Folia (or Folia-based fork).
+     * Otherwise, returns false, which means that plugin is running on Paper (or Paper-based fork).
+     *
+     * @return true if plugin is running on Folia (or Folia-based fork), otherwise false.
+     */
+    public boolean isFolia() {
+        return isFolia;
     }
 
     public static void registerListeners(Plugin plugin, Listener... listeners) {

--- a/src/main/java/ru/whitebeef/beeflibrary/utils/ScheduleUtils.java
+++ b/src/main/java/ru/whitebeef/beeflibrary/utils/ScheduleUtils.java
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeUnit;
 public class ScheduleUtils {
 
     public static void runTask(Runnable runnable) {
-        if (BeefLibrary.getInstance().isFoliaSupported()) {
+        if (BeefLibrary.getInstance().isFolia()) {
             Bukkit.getGlobalRegionScheduler().execute(BeefLibrary.getInstance(), runnable);
         } else {
             Bukkit.getScheduler().runTask(BeefLibrary.getInstance(), runnable);
@@ -17,7 +17,7 @@ public class ScheduleUtils {
     }
 
     public static void runTaskLater(Plugin plugin, Runnable runnable, long delay) {
-        if (BeefLibrary.getInstance().isFoliaSupported()) {
+        if (BeefLibrary.getInstance().isFolia()) {
             Bukkit.getGlobalRegionScheduler().runDelayed(plugin, (scheduledTask) -> runnable.run(), delay);
         } else {
             Bukkit.getScheduler().runTaskLater(plugin, runnable, delay);
@@ -25,7 +25,7 @@ public class ScheduleUtils {
     }
 
     public static void runTaskAsynchronously(Runnable runnable) {
-        if (BeefLibrary.getInstance().isFoliaSupported()) {
+        if (BeefLibrary.getInstance().isFolia()) {
             Bukkit.getAsyncScheduler().runNow(BeefLibrary.getInstance(), (scheduledTask) -> runnable.run());
         } else {
             Bukkit.getScheduler().runTaskAsynchronously(BeefLibrary.getInstance(), runnable);
@@ -33,7 +33,7 @@ public class ScheduleUtils {
     }
 
     public static void runTaskLaterAsynchronously(Plugin plugin, Runnable runnable, long delay) {
-        if (BeefLibrary.getInstance().isFoliaSupported()) {
+        if (BeefLibrary.getInstance().isFolia()) {
             Bukkit.getAsyncScheduler().runDelayed(BeefLibrary.getInstance(), (scheduledTask) -> runnable.run(), delay * 50, TimeUnit.MILLISECONDS);
         } else {
             Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, runnable, delay);
@@ -41,14 +41,14 @@ public class ScheduleUtils {
     }
 
     public static void scheduleSyncRepeatingTask(Plugin plugin, Runnable runnable, long delay, long period) {
-        if (BeefLibrary.getInstance().isFoliaSupported()) {
+        if (BeefLibrary.getInstance().isFolia()) {
             Bukkit.getGlobalRegionScheduler().runAtFixedRate(BeefLibrary.getInstance(), (scheduledTask) -> runnable.run(), delay, period);
         }
         Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, runnable, delay, period);
     }
 
     public static void scheduleAsyncRepeatingTask(Plugin plugin, Runnable runnable, long delay, long period) {
-        if (BeefLibrary.getInstance().isFoliaSupported()) {
+        if (BeefLibrary.getInstance().isFolia()) {
             Bukkit.getAsyncScheduler().runAtFixedRate(BeefLibrary.getInstance(), (scheduledTask) -> runnable.run(), delay * 50, period * 50, TimeUnit.MILLISECONDS);
         } else {
             Bukkit.getScheduler().scheduleAsyncRepeatingTask(plugin, runnable, delay, period);


### PR DESCRIPTION
Rename loadWithFolia field to isFolia and rewrite tryLoadWithFolia check (now it checks for Folia class instead of running isFoliaSupported method from PluginMeta).